### PR TITLE
Replace traffic light colors

### DIFF
--- a/src/charts/page_colors.js
+++ b/src/charts/page_colors.js
@@ -23,8 +23,8 @@ export const page_colors = {
   primary_color: '#7EBEC7',
   secondary_color: '#00263D',
   traffic_light_colors: {
-    high: '#BFE389',
-    mid: '#F5A623',
-    low: '#F04157'
+    high: '#3baa34',
+    mid: '#fd9c00',
+    low: '#e30713'
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -36,7 +36,7 @@ h6 {
   font-weight: 500;
 }
 .fa.fa-fas.fa-circle{
-  color: #83f509;
+  color: #3baa34;
   font-size: 1.3rem;
   padding: 0.1em;
 }
@@ -46,7 +46,7 @@ h6 {
   padding: 0.1em;
 }
 .fa.fa-circle-o{
-  color:#eb0d2a;
+  color:#e30713;
   font-size: 1.3rem;
   padding: 0.1em;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -36,17 +36,17 @@ h6 {
   font-weight: 500;
 }
 .fa.fa-fas.fa-circle{
-  color: #bfe398;
+  color: #83f509;
   font-size: 1.3rem;
   padding: 0.1em;
 }
 .fa.fa-fas.fa-adjust{
-  color:  #F5A623;
+  color:  #fd9c00;
   font-size: 1.3rem;
   padding: 0.1em;
 }
 .fa.fa-circle-o{
-  color:#F04157;
+  color:#eb0d2a;
   font-size: 1.3rem;
   padding: 0.1em;
 }


### PR DESCRIPTION
Should be more green, red and yellow/orange.

Example:
https://www.colourbox.com/vector/the-traffic-light-icon-stoplight-and-semaphore-crossroads-symbol-flat-vector-22097939