### PR TITLE
Add tool to analyze bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test"
+    "test": "react-scripts test",
+    "analyze": "source-map-explorer 'build/static/js/*.js'"
   },
   "repository": {
     "type": "git",
@@ -25,7 +26,8 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "^3.4.4",
-    "react-select": "^3.1.0"
+    "react-select": "^3.1.0",
+    "source-map-explorer": "^2.5.0"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
This tool is very helpful to keep the bundle size small.
We should carefully consider the size of dependencies we add and where we can code split to keep the app fast.