### PR TITLE
Add event handler for the Escape key

### DIFF
--- a/src/components/__tests__/tu_list.tsx
+++ b/src/components/__tests__/tu_list.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { act } from "react-dom/test-utils";
+import TU_LIST, { Props } from "../tu_list";
+
+describe("test open and close of tu_list", () => {
+  const props: Props = {
+    treatment_units: [""],
+    update_treatment_units: () => {},
+    tu_structure: [{ rhf: "", hf: [{ hf: "", hf_full: "", hospital: [""] }] }],
+  };
+  it("should initialy be hidden", () => {
+    const { container } = render(<TU_LIST {...props} />);
+    expect(container.getElementsByClassName("tu_list")[0]).toHaveStyle(
+      "display: none"
+    );
+  });
+  it("should show list of TUs when button 'Vis alle' is clicked", () => {
+    const { container } = render(<TU_LIST {...props} />);
+    act(() => {
+      userEvent.click(screen.getByText(/Vis alle/i));
+    });
+    expect(container.getElementsByClassName("tu_list")[0]).not.toHaveStyle(
+      "display: none"
+    );
+  });
+  it("should close the list of TUs when ESC/ESCAPE is clicked", () => {
+    const { container } = render(<TU_LIST {...props} />);
+    act(() => {
+      userEvent.click(screen.getByText(/Vis alle/i));
+    });
+    expect(container.getElementsByClassName("tu_list")[0]).not.toHaveStyle(
+      "display: none"
+    );
+    act(() => {
+      var event = new KeyboardEvent("keydown", { key: "Esc" });
+      global.dispatchEvent(event);
+    });
+    expect(container.getElementsByClassName("tu_list")[0]).toHaveStyle(
+      "display: none"
+    );
+  });
+});

--- a/src/components/tu_list.tsx
+++ b/src/components/tu_list.tsx
@@ -13,7 +13,7 @@ interface NestedTreatmentUnitName {
   }[];
 }
 
-interface Props {
+export interface Props {
   tu_structure: NestedTreatmentUnitName[];
   treatment_units: string[];
   update_treatment_units: (arg: string[]) => void;
@@ -59,7 +59,7 @@ const TU_LIST = (props: Props) => {
           Vis alle
         </button>
       </div>
-      <div style={style_tu_list} className="tu_list">
+      <div style={style_tu_list} className="tu_list" test-id="tu_list">
         <TU_LIST_HEADER />
         <div className="all_tu">{tu_str_elm}</div>
         <button

--- a/src/components/tu_list.tsx
+++ b/src/components/tu_list.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 
 import TU_LIST_HEADER from "./tu_list_header";
 import TU_LIST_BODY from "./tu_list_body";
+import useEventListener from "../helpers/hooks/useEventListener";
 
 interface NestedTreatmentUnitName {
   rhf: string;
@@ -20,7 +21,6 @@ interface Props {
 
 const TU_LIST = (props: Props) => {
   const { tu_structure, treatment_units, update_treatment_units } = props;
-
   const [tu_list_display, update_tu_list_display] = useState("none");
   const style_tu_list = { display: tu_list_display };
   const tu_str_elm = tu_structure.map((element) => {
@@ -33,6 +33,21 @@ const TU_LIST = (props: Props) => {
       />
     );
   });
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.defaultPrevented) {
+      return;
+    }
+    switch (event.key) {
+      case "Esc":
+      case "Escape":
+        update_tu_list_display("none");
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+  };
+  useEventListener("keydown", handleKeyDown);
 
   return (
     <>

--- a/src/helpers/hooks/useEventListener.tsx
+++ b/src/helpers/hooks/useEventListener.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from "react";
+
+export const useEventListener = (
+  eventName: string,
+  handler: Function,
+  targetElement = global
+) => {
+  const listenerRef = useRef<Function>();
+
+  useEffect(() => {
+    listenerRef.current = handler;
+  }, [handler]);
+
+  useEffect(() => {
+    const isSupported = targetElement && targetElement.addEventListener;
+    if (!isSupported) return;
+    const eventListener = (event: Event) =>
+      !!listenerRef.current && listenerRef.current(event);
+    targetElement.addEventListener(eventName, eventListener);
+    return () => {
+      targetElement.removeEventListener(eventName, eventListener);
+    };
+  }, [eventName, targetElement]);
+};
+
+export default useEventListener;


### PR DESCRIPTION
Added a generic useEventListener Hook function that kan handle most types of event listeners.
Used it to listen for ESC / ESCAPE keypresses and hide the "Vis alle" "window" when pressed.

Closes #86 