### PR TITLE
fix typo in github actions 

### DIFF
--- a/.github/workflows/qa-front-end.yml
+++ b/.github/workflows/qa-front-end.yml
@@ -23,6 +23,6 @@ jobs:
       - name: sync
         run: aws s3 sync build s3://qa.skde-resultater.no --delete --cache-control "public, max-age=31536000"
       - name: manifest
-        run: aws s3 cp build/asset-manifest.json s3://qa.skde-resultater.no/assets-manifest.json --cache-control "public, max-age=1, s-maxage=1"
+        run: aws s3 cp build/asset-manifest.json s3://qa.skde-resultater.no/asset-manifest.json --cache-control "public, max-age=1, s-maxage=1"
       - name: index
         run: aws s3 cp build/index.html s3://qa.skde-resultater.no/index.html --cache-control "public, max-age=1, s-maxage=1"


### PR DESCRIPTION
`build/asset-manifest.json` was pushed to the file `build/assets-manifest.json` (with an extra `s`) in the S3 bucket.
