### PR TITLE
Use verify-mong-api.skde.org/qa-mong-api.skde.org

### DIFF
--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -3,7 +3,7 @@ on:
   release:
     types: [published]
   push:
-    branches: [master, new_api_url]
+    branches: [master]
   pull_request:
     branches: [master, dependabot_updates]
 

--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -3,7 +3,7 @@ on:
   release:
     types: [published]
   push:
-    branches: [master]
+    branches: [master, new_api_url]
   pull_request:
     branches: [master, dependabot_updates]
 

--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set QA variables
         if: github.event_name == 'push'
         run: |
-          echo "api=https://d2mrl4o83i9jyx.cloudfront.net" >> $GITHUB_ENV
+          echo "api=https://qa-mong-api.skde.org" >> $GITHUB_ENV
           echo "s3_bucket=s3://qa.skde.org/kvalitetsregistre" >> $GITHUB_ENV
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
       - name: Build and sync to verify page
         if: github.event_name == 'release'
         env:
-          REACT_APP_API_HOST: https://d25giyx4mh4r8t.cloudfront.net
+          REACT_APP_API_HOST: https://verify-mong-api.skde.org
         run: |
           npm install && npm run build
           aws s3 sync build s3://verify.skde.org/kvalitetsregistre --delete --cache-control "public, max-age=31536000"


### PR DESCRIPTION
EC2 behind load balancer instead of cloudfront.
Thus, no cache of api data.