### PR TITLE
More robust level_bondary function

### DIFF
--- a/src/components/RegisterPage/indicatortable/chartrow/tr_utils.ts
+++ b/src/components/RegisterPage/indicatortable/chartrow/tr_utils.ts
@@ -1,13 +1,16 @@
 export interface Config {
-  level_direction: number;
+  level_direction: number | null;
   level_green: number | null;
   level_yellow: number | null;
 }
 
 export function level_boundary(config: Config) {
-  const level_direction = config.level_direction;
-  const level_yellow = config.level_yellow ?? 0;
-  const level_green = config.level_green ?? 0;
+  // Set level_direction to 1 if NULL
+  const level_direction = config.level_direction ?? 1;
+  // If level_green is NULL: set to 0 if level_direction is 1, and vice versa
+  const level_green = config.level_green ?? level_direction === 1 ? 0 : 1;
+  // If level_yellow is NULL: set to level_green
+  const level_yellow = config.level_yellow ?? level_green;
 
   switch (level_direction) {
     case 0:

--- a/src/components/RegisterPage/indicatortable/chartrow/tr_utils.ts
+++ b/src/components/RegisterPage/indicatortable/chartrow/tr_utils.ts
@@ -8,9 +8,13 @@ export function level_boundary(config: Config) {
   // Set level_direction to 1 if NULL
   const level_direction = config.level_direction ?? 1;
   // If level_green is NULL: set to 0 if level_direction is 1, and vice versa
-  const level_green = config.level_green ?? level_direction === 1 ? 0 : 1;
+  const level_green = config.level_green
+    ? config.level_green
+    : level_direction === 1
+    ? 0
+    : 1;
   // If level_yellow is NULL: set to level_green
-  const level_yellow = config.level_yellow ?? level_green;
+  const level_yellow = config.level_yellow ? config.level_yellow : level_green;
 
   switch (level_direction) {
     case 0:


### PR DESCRIPTION
If `level_green` is not defined, Målnivå will be green.

Closes #1414
Closes #270