### PR TITLE
Målnivåknapp manglet hvis grønt målnivå === 0

### DIFF
--- a/src/components/IndicatorTable/chartrow/__tests__/tr_utils.ts
+++ b/src/components/IndicatorTable/chartrow/__tests__/tr_utils.ts
@@ -32,6 +32,202 @@ test("level_direction 1", () => {
   `);
 });
 
+test("level_direction null will set it to 1", () => {
+  const config: Config = {
+    level_direction: null,
+    level_green: 0.9,
+    level_yellow: 0.8,
+    max_value: null,
+    min_value: null,
+  };
+
+  const levels = level_boundary(config);
+
+  expect(levels).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "end": 0.9,
+        "level": "high",
+        "start": 1,
+      },
+      Object {
+        "end": 0.8,
+        "level": "mid",
+        "start": 0.9,
+      },
+      Object {
+        "end": 0,
+        "level": "low",
+        "start": 0.8,
+      },
+    ]
+  `);
+});
+
+test("level_green 0", () => {
+  const config: Config = {
+    level_direction: 0,
+    level_green: 0,
+    level_yellow: 0.1,
+    max_value: null,
+    min_value: null,
+  };
+
+  const levels = level_boundary(config);
+
+  expect(levels).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "end": 0,
+        "level": "high",
+        "start": 0,
+      },
+      Object {
+        "end": 0,
+        "level": "mid",
+        "start": 0.1,
+      },
+      Object {
+        "end": 0.1,
+        "level": "low",
+        "start": 1,
+      },
+    ]
+  `);
+});
+
+test("level_green null, level_direction 0", () => {
+  // level_green should ideally have been set to level_yellow
+  // Perfect case for test driven development ...
+  const config: Config = {
+    level_direction: 0,
+    level_green: null,
+    level_yellow: 0.1,
+    max_value: null,
+    min_value: null,
+  };
+
+  const levels = level_boundary(config);
+
+  expect(levels).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "end": 0,
+        "level": "high",
+        "start": 1,
+      },
+      Object {
+        "end": 1,
+        "level": "mid",
+        "start": 0.1,
+      },
+      Object {
+        "end": 0.1,
+        "level": "low",
+        "start": 1,
+      },
+    ]
+  `);
+});
+
+test("level_green null, level_direction 1", () => {
+  // level_green should ideally have been set to level_yellow
+  // Perfect case for test driven development ...
+  const config: Config = {
+    level_direction: 1,
+    level_green: null,
+    level_yellow: 0.1,
+    max_value: null,
+    min_value: null,
+  };
+
+  const levels = level_boundary(config);
+
+  expect(levels).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "end": 0,
+        "level": "high",
+        "start": 1,
+      },
+      Object {
+        "end": 0.1,
+        "level": "mid",
+        "start": 0,
+      },
+      Object {
+        "end": 0,
+        "level": "low",
+        "start": 0.1,
+      },
+    ]
+  `);
+});
+
+test("level_green null, level_yellow null, level_direction 1", () => {
+  const config: Config = {
+    level_direction: 1,
+    level_green: null,
+    level_yellow: null,
+    max_value: null,
+    min_value: null,
+  };
+
+  const levels = level_boundary(config);
+
+  expect(levels).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "end": 0,
+        "level": "high",
+        "start": 1,
+      },
+      Object {
+        "end": 0,
+        "level": "mid",
+        "start": 0,
+      },
+      Object {
+        "end": 0,
+        "level": "low",
+        "start": 0,
+      },
+    ]
+  `);
+});
+
+test("level_yellow null", () => {
+  const config: Config = {
+    level_direction: 1,
+    level_green: 0.5,
+    level_yellow: null,
+    max_value: null,
+    min_value: null,
+  };
+
+  const levels = level_boundary(config);
+
+  expect(levels).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "end": 0.5,
+        "level": "high",
+        "start": 1,
+      },
+      Object {
+        "end": 0.5,
+        "level": "mid",
+        "start": 0.5,
+      },
+      Object {
+        "end": 0,
+        "level": "low",
+        "start": 0.5,
+      },
+    ]
+  `);
+});
+
 test("level_direction 0", () => {
   const config: Config = {
     level_direction: 0,

--- a/src/components/IndicatorTable/chartrow/chartrowbuttons.tsx
+++ b/src/components/IndicatorTable/chartrow/chartrowbuttons.tsx
@@ -155,7 +155,9 @@ const FigureButtons = (props: Props) => {
   ];
 
   const buttons = buttonValues
-    .filter((btn) => description.level_green || btn.class !== "btn-level")
+    .filter(
+      (btn) => description.level_green !== null || btn.class !== "btn-level"
+    )
     .map((btn) => {
       return (
         <button

--- a/src/components/IndicatorTable/chartrow/tr_utils.ts
+++ b/src/components/IndicatorTable/chartrow/tr_utils.ts
@@ -8,15 +8,18 @@ export interface Config {
 
 export function level_boundary(config: Config) {
   // Set level_direction to 1 if NULL
-  const level_direction = config.level_direction ?? 1;
-  // If level_green is NULL: set to 0 if level_direction is 1, and vice versa
-  const level_green = config.level_green
-    ? config.level_green
-    : level_direction === 1
-    ? 0
-    : 1;
+  const level_direction =
+    config.level_direction === null ? 1 : config.level_direction;
+  // If level_green is NULL: set level_green to 0 if level_direction is 1, and vice versa
+  const level_green =
+    config.level_green !== null
+      ? config.level_green
+      : level_direction === 1
+      ? 0
+      : 1;
   // If level_yellow is NULL: set to level_green
-  const level_yellow = config.level_yellow ? config.level_yellow : level_green;
+  const level_yellow =
+    config.level_yellow !== null ? config.level_yellow : level_green;
 
   switch (level_direction) {
     case 0:


### PR DESCRIPTION
I tillegg ble det feil i definisjonen av level_boundary av samme grunn.

0 og null blir begge false for ternary operator

Closes #1514