### PR TITLE
optimize: Fjern excessive fetching av indikatorer

### DIFF
--- a/src/components/IndicatorTable/chartrow/Chart.tsx
+++ b/src/components/IndicatorTable/chartrow/Chart.tsx
@@ -1,5 +1,4 @@
-import React, { useCallback, useEffect } from "react";
-import { UseQueryResult, useQueryClient } from "react-query";
+import { UseQueryResult } from "react-query";
 import { Description, StatisticData } from "../../RegisterPage";
 
 import BarChart, { Bar, BarStyle } from "../../Charts/BarChart";
@@ -35,58 +34,17 @@ export default Chart;
 
 const GetBarChart: React.FC<Props> = (props) => {
   const { description, indicatorData, treatmentYear } = props;
-  const queryClient = useQueryClient();
   const registerShortName = description.rname ?? "";
   const {
     isLoading,
     error,
     data: indQryData,
   } = useIndicatorQuery({
-    queryKey: `indicatorDataBarChart`,
     registerShortName: registerShortName,
     treatmentYear: treatmentYear,
     context: props.context.context,
     type: props.context.type,
   });
-
-  const refetch = useCallback(() => {
-    return queryClient.fetchQuery([
-      "indicatorDataBarChart",
-      registerShortName,
-      props.context.context,
-      props.context.type,
-    ]);
-  }, [
-    queryClient,
-    registerShortName,
-    props.context.context,
-    props.context.type,
-  ]);
-
-  const cancel = useCallback(() => {
-    return queryClient.cancelQueries([
-      "indicatorDataBarChart",
-      registerShortName,
-      props.context.context,
-      props.context.type,
-    ]);
-  }, [
-    queryClient,
-    registerShortName,
-    props.context.context,
-    props.context.type,
-  ]);
-
-  useEffect(() => {
-    cancel();
-    refetch();
-  }, [
-    refetch,
-    cancel,
-    treatmentYear,
-    props.context.context,
-    props.context.type,
-  ]);
 
   if (isLoading) return <>Loading...</>;
   if (error) return <>An error has occured: {error.message}</>;
@@ -168,56 +126,12 @@ const GetBarChart: React.FC<Props> = (props) => {
 const GetLineChart: React.FC<Props> = (props) => {
   const { description, selectedTreatmentUnits } = props;
 
-  const queryClient = useQueryClient();
-  const unitNameString = selectedTreatmentUnits.join();
-
-  const registerShortName = description.rname ?? "";
-
   const lineChartQuery: UseQueryResult<any, unknown> = useIndicatorQuery({
-    queryKey: `indicatorDatalineChart`,
     registerShortName: description.rname ?? "",
     unitNames: selectedTreatmentUnits,
     context: props.context.context,
     type: props.context.type,
   });
-  const refetch = useCallback(() => {
-    return queryClient.fetchQuery([
-      "indicatorDatalineChart",
-      registerShortName,
-      props.context.context,
-      props.context.type,
-    ]);
-  }, [
-    queryClient,
-    registerShortName,
-    props.context.context,
-    props.context.type,
-  ]);
-
-  const cancel = useCallback(() => {
-    return queryClient.cancelQueries([
-      "indicatorDatalineChart",
-      registerShortName,
-      props.context.context,
-      props.context.type,
-    ]);
-  }, [
-    queryClient,
-    registerShortName,
-    props.context.context,
-    props.context.type,
-  ]);
-
-  useEffect(() => {
-    cancel();
-    refetch();
-  }, [
-    unitNameString,
-    cancel,
-    refetch,
-    props.context.context,
-    props.context.type,
-  ]);
 
   // get the last year with complete data
   const lastCompleteYear: number | undefined = lineChartQuery.data

--- a/src/components/IndicatorTable/tableblock/tableblock.tsx
+++ b/src/components/IndicatorTable/tableblock/tableblock.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo, useCallback } from "react";
-import { UseQueryResult, useQueryClient } from "react-query";
+import React, { useMemo } from "react";
+import { UseQueryResult } from "react-query";
 
 import style from "./tableblock.module.css";
 import { useDescriptionQuery, useIndicatorQuery } from "../../../helpers/hooks";
@@ -38,66 +38,19 @@ export const TableBlock: React.FC<TableBlockProps> = (props) => {
     context === "coverage"
       ? { context: "caregiver", type: "dg" }
       : { context, type: "ind" };
-  const unitNamesYearString = `${unitNames.toString()}${treatmentYear.toString()}`;
-  const queryClient = useQueryClient();
 
   const indicatorDataQuery: UseQueryResult<any, unknown> = useIndicatorQuery({
-    queryKey: "indicatorData",
     registerShortName: registerName.rname,
     unitNames,
     treatmentYear,
     type: queryContext.type,
     context: queryContext.context,
   });
+  const { isFetching } = indicatorDataQuery;
 
   const descriptionQuery: UseQueryResult<any, unknown> = useDescriptionQuery({
     registerShortName: registerName.rname,
   });
-
-  const isFetching = queryClient.getQueryState([
-    "indicatorData",
-    registerName.rname,
-  ])?.isFetching;
-
-  const refetch = useCallback(() => {
-    return queryClient.fetchQuery([
-      "indicatorData",
-      registerName.rname,
-      queryContext.context,
-      queryContext.type,
-    ]);
-  }, [
-    queryClient,
-    registerName.rname,
-    queryContext.context,
-    queryContext.type,
-  ]);
-
-  const cancel = useCallback(() => {
-    return queryClient.cancelQueries([
-      "indicatorData",
-      registerName.rname,
-      queryContext.context,
-      queryContext.type,
-    ]);
-  }, [
-    queryClient,
-    registerName.rname,
-    queryContext.context,
-    queryContext.type,
-  ]);
-
-  useEffect(() => {
-    cancel();
-    refetch();
-  }, [
-    refetch,
-    cancel,
-    treatmentYear,
-    queryContext.context,
-    queryContext.type,
-    unitNamesYearString,
-  ]);
 
   const uniqueOrderedInd: string[] = useMemo(
     () =>

--- a/src/helpers/hooks/apihooks.ts
+++ b/src/helpers/hooks/apihooks.ts
@@ -31,7 +31,6 @@ export const useDescriptionQuery = (params: FetchDescriptionParams) => {
 };
 
 export interface FetchIndicatorParams {
-  queryKey: string;
   registerShortName: string;
   treatmentYear?: number;
   unitNames?: string[];
@@ -70,7 +69,7 @@ const fetchIndicators = async (params: FetchIndicatorParams) => {
 
 export const useIndicatorQuery = (params: FetchIndicatorParams) => {
   return useQuery<StatisticData[], Error>(
-    [params.queryKey, params.registerShortName, params.context, params.type],
+    ["indicatorQuery", params],
     () => fetchIndicators(params),
     {
       staleTime: 1000 * 60 * 60,


### PR DESCRIPTION
React Query håndterer queries slik at man ikke må refetche for hver gang, samt man må ikke lage egne query keys da den selv deterministisk lager det basert på et objekt, slik som query params se: https://react-query-v3.tanstack.com/guides/query-keys 

I og med at query henter bar chart data for alle bar charts på siden som er åpen så gjør det at den kun kjører 1 query for hvert register. Framfor 1 per chart. Kan potensielt fikse feil da jeg ser ikke alle query params ble lagt inn i query keyen.

Samt man går fra 189 -> 134 requests når man åpner [alle siden](https://skde.org/kvalitetsregistre/alle/sykehus)

#1428 