### PR TITLE
Replace ReactDOM.render with createRoot

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import loadDevTools from "./dev-tools/load";
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
 import "./index.css";
@@ -27,14 +27,16 @@ if (process.env.REACT_APP_SENTRY) {
 
 const queryClient = new QueryClient();
 
+const container = document.getElementById("root");
+const root = createRoot(container!);
+
 loadDevTools(() =>
-  ReactDOM.render(
+  root.render(
     <React.StrictMode>
       <QueryClientProvider client={queryClient}>
         <App />
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>
-    </React.StrictMode>,
-    document.getElementById("root")
+    </React.StrictMode>
   )
 );


### PR DESCRIPTION
ReactDOM.render is no longer supported in React 18. See https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis

Closes #1585