### PR TITLE
Moved and renamed SelectYear and SelectTreatmentUnits code

### DIFF
--- a/src/components/RegisterPage/MainRegister.tsx
+++ b/src/components/RegisterPage/MainRegister.tsx
@@ -1,13 +1,12 @@
 import React, { useState, useRef, useEffect } from "react";
 import { UseQueryResult } from "react-query";
+import { useParams } from "react-router-dom";
 import { useQueryParam } from "use-query-params";
 
-import { useParams } from "react-router-dom";
+import SelectTreatmentUnits, { OptsTu } from "../SelectTreatmentUnits";
+import SelectYear from "../SelectYear";
 
-import MAIN from "./main_component";
 import { Header } from "./header";
-import SELECT_MULTI, { OptsTu } from "../select_multi";
-import SELECT_SINGLE from "../select_single";
 
 import config, {
   mainQueryParamsConfig,
@@ -18,9 +17,11 @@ import config, {
 
 import { useResizeObserver, useUnitNamesQuery } from "../../helpers/hooks";
 import { mathClamp, validateTreatmentUnits } from "../../helpers/functions";
-import { RegisterNames } from ".";
 import { UnitNameList } from "./unitnamelist";
 import { NestedTreatmentUnitName } from "./unitnamelist/unitnamelistbody";
+import { RegisterNames } from ".";
+
+import MAIN from "./main_component";
 
 const { app_text } = config;
 
@@ -132,7 +133,7 @@ const MainRegister: React.FC<MainRegisterProps> = ({ registerNames }) => {
       <div className="app-body">
         <div className="selection-container" ref={selection_bar_ref}>
           <div className="treatment-unit-selection">
-            <SELECT_MULTI
+            <SelectTreatmentUnits
               opts={optstu}
               update_tu={update_treatment_units}
               treatment_unit={validated_treatment_units}
@@ -145,7 +146,7 @@ const MainRegister: React.FC<MainRegisterProps> = ({ registerNames }) => {
             />
           </div>
           <div className="year-selection">
-            <SELECT_SINGLE
+            <SelectYear
               opts={valid_years}
               update_year={update_selected_year}
               selected_year={validated_selected_year}

--- a/src/components/RegisterPage/SelectedRegister.tsx
+++ b/src/components/RegisterPage/SelectedRegister.tsx
@@ -3,27 +3,30 @@ import { useQueryParam } from "use-query-params";
 import { useParams } from "react-router-dom";
 import { UseQueryResult } from "react-query";
 
-import SELECT_MULTI from "../select_multi";
-import SELECT_SINGLE from "../select_single";
-import LEGEND from "../TargetLevels";
-import { IndicatorTable } from "../IndicatorTable";
-import { RegisterNames } from ".";
-import { OptsTu } from "../select_multi";
+import SelectTreatmentUnits, { OptsTu } from "../SelectTreatmentUnits";
+import SelectYear from "../SelectYear";
+
+import { Header } from "./header";
+
 import config, {
   mainQueryParamsConfig,
   maxYear,
   minYear,
   defaultYear,
 } from "../../app_config";
-import { mathClamp, validateTreatmentUnits } from "../../helpers/functions";
+
 import {
   useResizeObserver,
   useUnitNamesQuery,
   useSelectionYearsQuery,
 } from "../../helpers/hooks";
-import { Header } from "./header";
+import { mathClamp, validateTreatmentUnits } from "../../helpers/functions";
 import { UnitNameList } from "./unitnamelist";
 import { NestedTreatmentUnitName } from "./unitnamelist/unitnamelistbody";
+import { RegisterNames } from ".";
+
+import LEGEND from "../TargetLevels";
+import { IndicatorTable } from "../IndicatorTable";
 
 interface SelectedRegisterProps {
   registerNames: RegisterNames[];
@@ -166,7 +169,7 @@ export const SelectedRegister: React.FC<SelectedRegisterProps> = ({
       <div className="app-body">
         <div className="selection-container" ref={selection_bar_ref}>
           <div className="treatment-unit-selection">
-            <SELECT_MULTI
+            <SelectTreatmentUnits
               opts={optstu}
               update_tu={update_treatment_units}
               treatment_unit={validated_treatment_units}
@@ -179,7 +182,7 @@ export const SelectedRegister: React.FC<SelectedRegisterProps> = ({
             />
           </div>
           <div className="year-selection">
-            <SELECT_SINGLE
+            <SelectYear
               opts={valid_years.sort()}
               update_year={update_selected_year}
               selected_year={validated_selected_year}

--- a/src/components/RegisterPage/main_component.tsx
+++ b/src/components/RegisterPage/main_component.tsx
@@ -7,7 +7,7 @@ import LEGEND from "../TargetLevels";
 import { MedicalFields } from "../MedicalFields";
 import { IndicatorTable } from "../IndicatorTable";
 import { useMedicalFieldsQuery } from "../../helpers/hooks";
-import { OptsTu } from "../select_multi";
+import { OptsTu } from "../SelectTreatmentUnits";
 
 interface AggData {
   nation: {

--- a/src/components/SelectTreatmentUnits/index.tsx
+++ b/src/components/SelectTreatmentUnits/index.tsx
@@ -1,6 +1,6 @@
 import Select from "react-select";
 
-import { app_text } from "../app_config";
+import { app_text } from "../../app_config";
 
 export interface OptsTu {
   label: string;
@@ -18,7 +18,7 @@ interface Props {
   treatment_unit: string[];
 }
 
-function SELECT_MULTI(props: Props) {
+function SelectTreatmentUnits(props: Props) {
   const {
     opts = [],
     select_className = "pick_treatment_unit",
@@ -111,4 +111,4 @@ function SELECT_MULTI(props: Props) {
   );
 }
 
-export default SELECT_MULTI;
+export default SelectTreatmentUnits;

--- a/src/components/SelectYear/index.tsx
+++ b/src/components/SelectYear/index.tsx
@@ -5,7 +5,7 @@ interface Props {
   update_year(int: number): void;
   selected_year: number;
 }
-function SELECT_SINGLE(props: Props) {
+function SelectYear(props: Props) {
   const {
     opts = [],
     select_className = "pick_year",
@@ -69,4 +69,4 @@ function SELECT_SINGLE(props: Props) {
   );
 }
 
-export default SELECT_SINGLE;
+export default SelectYear;


### PR DESCRIPTION
`SELECT_SINGLE` and `SELECT_MULTI` were not very informative names.